### PR TITLE
fix: all endpoint should return json

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -145,7 +145,8 @@ disable=print-statement,
         wildcard-import,
         line-too-long,
         too-many-ancestors,
-        inconsistent-return-statements
+        inconsistent-return-statements,
+        no-self-use
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/hyperion/authentication.py
+++ b/hyperion/authentication.py
@@ -1,0 +1,62 @@
+import base64
+import binascii
+
+from django.contrib.auth import authenticate, get_user_model
+from django.utils.translation import ugettext_lazy as _
+
+from rest_framework.authentication import BaseAuthentication, get_authorization_header
+from rest_framework import HTTP_HEADER_ENCODING, exceptions
+
+class HyperionBasicAuthentication(BaseAuthentication):
+    """
+    HTTP Basic authentication against username/password.
+    """
+    www_authenticate_realm = 'api'
+
+    def authenticate(self, request):
+        """
+        Returns a `User` if a correct username and password have been supplied
+        using HTTP Basic authentication.  Otherwise returns `None`.
+        """
+        auth = get_authorization_header(request).split()
+
+        if not auth or auth[0].lower() != b'basic':
+            return None
+
+        if len(auth) == 1:
+            msg = _('Invalid basic header. No credentials provided.')
+            raise exceptions.AuthenticationFailed(msg)
+        elif len(auth) > 2:
+            msg = _('Invalid basic header. Credentials string should not contain spaces.')
+            raise exceptions.AuthenticationFailed(msg)
+
+        try:
+            auth_parts = base64.b64decode(auth[1]).decode(HTTP_HEADER_ENCODING).partition(':')
+        except (TypeError, UnicodeDecodeError, binascii.Error):
+            msg = _('Invalid basic header. Credentials not correctly base64 encoded.')
+            raise exceptions.AuthenticationFailed(msg)
+
+        userid, password = auth_parts[0], auth_parts[2]
+        return self.authenticate_credentials(userid, password, request)
+
+    def authenticate_credentials(self, userid, password, request=None):
+        """
+        Authenticate the userid and password against username and password
+        with optional request for context.
+        """
+        credentials = {
+            get_user_model().USERNAME_FIELD: userid,
+            'password': password
+        }
+        user = authenticate(request=request, **credentials)
+
+        if user is None:
+            raise exceptions.AuthenticationFailed(_('Invalid username/password.'))
+
+        if not user.is_active:
+            raise exceptions.AuthenticationFailed(_('User inactive or deleted.'))
+
+        return (user, None)
+
+    def authenticate_header(self, request):
+        return 'Nice try'

--- a/hyperion/tests/tests_friend_views.py
+++ b/hyperion/tests/tests_friend_views.py
@@ -1,13 +1,20 @@
-from django.test import TestCase, Client
+import json
+import copy
+import base64
+
+from django.test import TestCase, Client, RequestFactory
 from django.contrib.auth.models import User
 from hyperion.models import UserProfile, Friend, FriendRequest, Server
 from hyperion.serializers import UserSerializer, UserProfileSerializer, FriendRequestSerializer
 
-import json
-import copy
-
 
 class FriendViewTestCase(TestCase):
+    username = 'testUser'
+    password = 'test'
+
+    def setUp(self):
+        credentials = base64.b64encode('{}:{}'.format(self.username, self.password).encode()).decode()
+        self.client = Client(HTTP_AUTHORIZATION='Basic {}'.format(credentials))
 
     @classmethod
     def setUpTestData(cls):
@@ -82,9 +89,6 @@ class FriendViewTestCase(TestCase):
         return len(l1) == len(l2) and sorted(l1) == sorted(l2)
 
     def test_friend_list_get(self):
-        self.client.login(username='testUser', password='test')
-        self.assertTrue(self.u1.is_authenticated)
-
         response = self.client.get('/author/{}/friends'.format(self.u1.id))
         self.assertEqual(response.status_code, 200)
         friends = list(self.u1.profile.get_friends())
@@ -92,9 +96,7 @@ class FriendViewTestCase(TestCase):
                                            many=True,
                                            context={'fields': ['id', "host", "display_name", "url"]})
         content = {"query": "friends", "count": len(friends), "author": serializer.data}
-        self.assertEqual(response.data, json.dumps(content))
-        # print(response.data)
-        self.client.logout()
+        self.assertEqual(response.data, content)
 
     def test_friend_list_post(self):
         post_body = {
@@ -123,7 +125,7 @@ class FriendViewTestCase(TestCase):
         result_body["authors"].remove("https://cmput404-front-t2.herokuapp.com/author/100")
         # print(json.loads(response.data))
 
-        response_data = json.loads(response.data)
+        response_data = response.data
         self.assertTrue(self._check_list_equal(result_body["authors"], response_data["authors"]))
         self.assertEqual(response_data["query"], "friends")
         self.assertEqual(response_data["author"], str(self.u1.id))
@@ -134,7 +136,7 @@ class FriendViewTestCase(TestCase):
             .format(self.u1.id)
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        response_data = json.loads(response.data)
+        response_data = response.data
         self.assertEqual(response_data['friends'], False)
         # print(response.data)
 
@@ -143,21 +145,21 @@ class FriendViewTestCase(TestCase):
             .format(self.u1.id)
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        response_data = json.loads(response.data)
+        response_data = response.data
         self.assertEqual(response_data['friends'], True)
 
         # check local friend (not friend with author1)
         url = "/author/{}/friends/cmput404-front.herokuapp.com/author/{}".format(self.u1.id, self.u4.id)
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        response_data = json.loads(response.data)
+        response_data = response.data
         self.assertEqual(response_data['friends'], False)
 
         # check local friend (friend with author1)
         url = "/author/{}/friends/cmput404-front.herokuapp.com/author/{}".format(self.u1.id, self.u2.id)
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        response_data = json.loads(response.data)
+        response_data = response.data
         self.assertEqual(response_data['friends'], True)
 
     def test_friend_request_post(self):
@@ -261,16 +263,8 @@ class FriendViewTestCase(TestCase):
         }
         self.client.post("/friendrequest", post_body, content_type='application/json')
 
-        # then test get
-        response = self.client.get('/friendrequest')
-        self.assertEqual(response.status_code, 401)
-        self.client.login(username='testUser', password='test')
-        self.assertTrue(self.u1.is_authenticated)
-
         response = self.client.get('/friendrequest')
         self.assertEqual(response.status_code, 200)
-        # print(response.data)
-        self.client.logout()
 
     def test_action_friend_request(self):
         # first send friend request firstly
@@ -300,10 +294,6 @@ class FriendViewTestCase(TestCase):
         }
         self.client.post("/friendrequest", post_body, content_type='application/json')
 
-        # then test action
-        self.client.login(username='testUser', password='test')
-        self.assertTrue(self.u1.is_authenticated)
-
         # accept action (u1 and u5)
         friend_request_u5_u1 = FriendRequest.objects.get(to_profile=self.u1.profile, from_profile=self.u5.profile)
         serializer = FriendRequestSerializer(friend_request_u5_u1,
@@ -323,7 +313,7 @@ class FriendViewTestCase(TestCase):
         url = "/author/{}/friends/cmput404-front.herokuapp.com/author/{}".format(self.u1.id, self.u5.id)
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        response_data = json.loads(response.data)
+        response_data = response.data
         self.assertEqual(response_data['friends'], True)
 
         # decline action (u1 and fu1)
@@ -345,7 +335,7 @@ class FriendViewTestCase(TestCase):
         url = "/author/{}/friends/cmput404-front.herokuapp.com/author/1d698d25ff008f7538453c120f581471".format(self.u1.id)
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        response_data = json.loads(response.data)
+        response_data = response.data
         self.assertEqual(response_data['friends'], False)
 
 

--- a/hyperion/tests/tests_friend_views.py
+++ b/hyperion/tests/tests_friend_views.py
@@ -2,7 +2,7 @@ import json
 import copy
 import base64
 
-from django.test import TestCase, Client, RequestFactory
+from django.test import TestCase, Client
 from django.contrib.auth.models import User
 from hyperion.models import UserProfile, Friend, FriendRequest, Server
 from hyperion.serializers import UserSerializer, UserProfileSerializer, FriendRequestSerializer

--- a/hyperion/views/auth_views.py
+++ b/hyperion/views/auth_views.py
@@ -1,8 +1,6 @@
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from rest_framework.authentication import BasicAuthentication
 from rest_framework.permissions import IsAuthenticated, AllowAny
-from rest_framework.exceptions import AuthenticationFailed
 
 from hyperion.serializers import UserSerializer
 from hyperion.authentication import HyperionBasicAuthentication

--- a/hyperion/views/auth_views.py
+++ b/hyperion/views/auth_views.py
@@ -5,21 +5,12 @@ from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework.exceptions import AuthenticationFailed
 
 from hyperion.serializers import UserSerializer
+from hyperion.authentication import HyperionBasicAuthentication
 
 
 class AuthView(APIView):
-    authentication_classes = (BasicAuthentication,)
+    authentication_classes = (HyperionBasicAuthentication,)
     permission_classes = (IsAuthenticated, AllowAny)
-
-    # https://stackoverflow.com/questions/18262643/adding-custom-response-headers-to-apiexception
-    # https://stackoverflow.com/questions/86105/how-can-i-suppress-the-browsers-authentication-dialog
-    def handle_exception(self, exc):
-        if isinstance(exc, AuthenticationFailed):
-            self.headers['WWW-Authenticate'] = ""
-            return Response({'detail': exc.detail},
-                            status=exc.status_code, exception=True)
-        else:
-            super(AuthView, self).handle_exception(exc)
 
     def get(self, request):
         user = UserSerializer(request.user, context={'request': request})

--- a/hyperion/views/friend_views.py
+++ b/hyperion/views/friend_views.py
@@ -2,7 +2,6 @@
 import json
 from urllib.parse import urlparse
 from rest_framework.decorators import api_view, permission_classes, authentication_classes
-from rest_framework.authentication import BasicAuthentication
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework import permissions


### PR DESCRIPTION
## Description
Serveral endpoints are not enforcing basic authentication.

Create a new custom authentication class that can be reused everywhere.

Also fix test cases.

## Check list

- [x] My branch is up to date with `master`. [How?](https://github.com/ExiaSR/hyperion/wiki/How-to-collaborate)
- [x] I passed all integration tests in Travis CI.
- [x] Now it is a good time to ask for review.
