### PR TITLE
chore(ci): dynamic test db name to race condition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
       install:
         - pip install -r requirements.txt
       script:
+        - export TEST_POSTGRES_NAME=${TRAVIS_COMMIT::8}
         - python manage.py test --noinput
         - pylint api && pylint hyperion
     - language: node_js
@@ -26,3 +27,7 @@ matrix:
         - yarn install
       script:
         - yarn test
+notifications:
+  email:
+    on_success: never
+    on_failure: always

--- a/api/config.py
+++ b/api/config.py
@@ -11,7 +11,7 @@ POSTGRES_PORT = os.environ.get('CMPUT404_POSTGRES_PORT', None)
 POSTGRES_NAME = os.environ.get('CMPUT404_POSTGRES_NAME', None)
 POSTGRES_USER = os.environ.get('CMPUT404_POSTGRES_USER', None)
 POSTGRES_PASSWORD = os.environ.get('CMPUT404_POSTGRES_PASSWORD', None)
-
+TEST_POSTGRES_NAME = 'test_{}'.format(os.environ.get('TEST_POSTGRES_NAME', 'default'))
 
 ############ App environment variables ###################
 

--- a/api/settings.py
+++ b/api/settings.py
@@ -96,7 +96,10 @@ DATABASES = {
         'PORT': POSTGRES_PORT,
         'NAME': POSTGRES_NAME,
         'USER': POSTGRES_USER,
-        'PASSWORD': POSTGRES_PASSWORD
+        'PASSWORD': POSTGRES_PASSWORD,
+        'TEST': {
+            'NAME': TEST_POSTGRES_NAME
+        }
     }
 }
 


### PR DESCRIPTION
Concurrent CI testing always results in race condition to our test DB.

Use git commit hash (first 8 char) as a part of the
test DB name to avoid multiple jobs accessing the same database at the same time

## Check list

- [x] My branch is up to date with `master`. [How?](https://github.com/ExiaSR/hyperion/wiki/How-to-collaborate)
- [x] I passed all integration tests in Travis CI.
- [ ] Now it is a good time to ask for review.
