### PR TITLE
fix: invalid post api response query name

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -1,0 +1,3 @@
+[style]
+based_on_style = pep8
+SPACE_BETWEEN_ENDING_COMMA_AND_CLOSING_BRACKET = false

--- a/client/package.json
+++ b/client/package.json
@@ -40,6 +40,14 @@
     "*.{json,md,scss,yaml,yml}": [
       "prettier --write",
       "git add"
+    ],
+    "../hyperion/**/*.py": [
+      "yapf -i ",
+      "git add"
+    ],
+    "../api/**/*.py": [
+      "yapf -i ",
+      "git add"
     ]
   },
   "husky": {

--- a/hyperion/tests/tests_post_api.py
+++ b/hyperion/tests/tests_post_api.py
@@ -18,76 +18,53 @@ class PostViewTestCase(TestCase):
             username='2haotianzhu',
             first_name='haotian',
             last_name='zhu',
-            password='123456'
-        )
+            password='123456')
         self.u_2 = User.objects.create_user(
             username='hyuntian',
             first_name='yuntian',
             last_name='zhang',
-            password='123456'
-        )
-        credentials = base64.b64encode('{}:{}'.format(self.username, self.password).encode()).decode()
+            password='123456')
+        credentials = base64.b64encode('{}:{}'.format(
+            self.username, self.password).encode()).decode()
         self.client = Client(HTTP_AUTHORIZATION='Basic {}'.format(credentials))
 
     def test_get_one(self):
         Post.objects.create(
-            author=self.u_1.profile,
-            title="1",
-            content="test1"
-        )
+            author=self.u_1.profile, title="1", content="test1")
         response = self.client.get('/posts')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['posts']), 1)
-        self.assertEqual(
-            response.data['posts'][0]['author']['display_name'],
-            '2haotianzhu'
-        )
+        self.assertEqual(response.data['posts'][0]['author']['display_name'],
+                         '2haotianzhu')
 
     def test_get_many(self):
         Post.objects.create(
-            author=self.u_1.profile,
-            title="2",
-            content="test2"
-        )
+            author=self.u_1.profile, title="2", content="test2")
         Post.objects.create(
-            author=self.u_1.profile,
-            title="3",
-            content="test3"
-        )
+            author=self.u_1.profile, title="3", content="test3")
         response = self.client.get('/posts')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['posts']), 2)
 
     def test_get_post_by_id(self):
         Post.objects.create(
-            author=self.u_1.profile,
-            title="4",
-            content="test4"
-        )
+            author=self.u_1.profile, title="4", content="test4")
         the_id = Post.objects.get().pk
         path = '/posts/{}'.format(the_id)
         response = self.client.get(path)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            response.data['post']['author']['display_name'],
-            '2haotianzhu'
-        )
+        self.assertEqual(response.data['post']['author']['display_name'],
+                         '2haotianzhu')
 
     def test_get_auth_posts(self):
         # get post by auth
         Post.objects.create(
-            author=self.u_1.profile,
-            title="5",
-            content="test5"
-        )
+            author=self.u_1.profile, title="5", content="test5")
         Post.objects.create(
-            author=self.u_2.profile,
-            title="6",
-            content="test6"
-        )
+            author=self.u_2.profile, title="6", content="test6")
         response = self.client.get('/author/posts')
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data['query'], 'visiblePosts')
+        self.assertEqual(response.data['query'], 'posts')
         self.assertEqual(len(response.data['posts']), 1)
 
     def test_auth_post_a_post(self):
@@ -99,11 +76,10 @@ class PostViewTestCase(TestCase):
                 "content": "some post content",
             }
         }
-        response = self.client.post('/author/posts', data, content_type='application/json')
+        response = self.client.post(
+            '/author/posts', data, content_type='application/json')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data['query'], 'createPost')
         self.assertEqual(response.data['success'], True)
-        self.assertEqual(
-            Post.objects.all()[0].author.display_name,
-            '2haotianzhu'
-        )
+        self.assertEqual(Post.objects.all()[0].author.display_name,
+                         '2haotianzhu')

--- a/hyperion/views/post_views.py
+++ b/hyperion/views/post_views.py
@@ -29,20 +29,21 @@ class PostViewSet(viewsets.ModelViewSet):
         post_data = body.get('post', None)
         if post_query == 'createPost' and post_data:
             post_data['visible_to'] = post_data.get('visible_to', [])
-            serializer = PostSerializer(data=post_data, context={'request': request})
+            serializer = PostSerializer(
+                data=post_data, context={'request': request})
             if serializer.is_valid():
                 serializer.save()
-                return Response(
-                    {'query': 'createPost',
-                     'success': True,
-                     'message': 'Author Post Created'
-                     })
+                return Response({
+                    'query': 'createPost',
+                    'success': True,
+                    'message': 'Author Post Created'
+                })
             else:
-                return Response(
-                    {'query': 'createPost',
-                     'success': False,
-                     'message': serializer.errors
-                     })
+                return Response({
+                    'query': 'createPost',
+                    'success': False,
+                    'message': serializer.errors
+                })
 
     @action(detail=True, methods=['GET'], name='get_auth_posts')
     def get_auth_posts(self, request):
@@ -50,11 +51,9 @@ class PostViewSet(viewsets.ModelViewSet):
         GET /author/posts
         '''
         serializer = PostSerializer(
-            self.queryset.filter(author=request.user.profile),
-            many=True
-        )
+            self.queryset.filter(author=request.user.profile), many=True)
         return Response({
-            'query': 'visiblePosts',
+            'query': 'posts',
             'count': len(serializer.data),
             'posts': serializer.data
         })
@@ -65,11 +64,7 @@ class PostViewSet(viewsets.ModelViewSet):
         '''
         response = super().list(request)
         data = response.data
-        response.data = {
-            'query': 'publicPosts',
-            'count': len(data),
-            'posts': data
-        }
+        response.data = {'query': 'posts', 'count': len(data), 'posts': data}
         return response
 
     def retrieve(self, request, pk):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,10 +6,10 @@ Click==7.0
 coreapi==2.3.3
 coreschema==0.0.4
 dj-database-url==0.5.0
-Django==2.1.5
+Django==2.1.7
 django-cors-headers==2.4.0
 django-heroku==0.3.1
-djangorestframework==3.9.0
+djangorestframework==3.9.1
 Flask==1.0.2
 gunicorn==19.9.0
 idna==2.8
@@ -21,8 +21,8 @@ lazy-object-proxy==1.3.1
 Markdown==3.0.1
 MarkupSafe==1.1.0
 mccabe==0.6.1
-psycopg2==2.7.6.1
-psycopg2-binary==2.7.6.1
+psycopg2==2.7.7
+psycopg2-binary==2.7.7
 pycodestyle==2.4.0
 Pygments==2.3.1
 pylint==2.2.2
@@ -36,3 +36,4 @@ urllib3==1.24.1
 Werkzeug==0.14.1
 whitenoise==4.1.2
 wrapt==1.11.1
+yapf==0.26.0


### PR DESCRIPTION
## Fixed
- return `query` name is not consistent with the spec

## Added
- use `yapf` in pre-commit hook to autoformat python code

## References
- https://github.com/abramhindle/CMPUT404-project-socialdistribution/blob/master/example-article.json#L26

## Check list

- [x] My branch is up to date with `master`. [How?](https://github.com/ExiaSR/hyperion/wiki/How-to-collaborate)
- [x] I passed all integration tests in Travis CI.
- [x] Now it is a good time to ask for review.
