### PR TITLE
feat: add 'is_active' field to UserSerializer

### DIFF
--- a/hyperion/models/user.py
+++ b/hyperion/models/user.py
@@ -61,6 +61,12 @@ class UserProfile(models.Model):
         else:
             return self.url
 
+    def get_url(self):
+        if self.url:
+            return self.url
+        else:
+            return self.get_full_id()
+
     def get_type(self):
         # return UserProfile class either host or foreign
         if self.host and self.author is None:

--- a/hyperion/serializers.py
+++ b/hyperion/serializers.py
@@ -23,7 +23,7 @@ class UserSerializer(serializers.ModelSerializer):
     display_name = serializers.CharField(
         source='profile.display_name', max_length=20)
     id = serializers.CharField(source='profile.get_full_id')
-    url = serializers.CharField(source='profile.url', max_length=200)
+    url = serializers.CharField(source='profile.get_url')
     github = serializers.CharField(
         source='profile.github',
         max_length=200,
@@ -33,7 +33,7 @@ class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = ('id', 'username', 'email', 'bio', 'host', 'first_name',
-                  'last_name', 'display_name', 'url', 'github')
+                  'last_name', 'display_name', 'url', 'github', 'is_active')
 
     # Not sure if this solution effects create/update
     def to_representation(self, instance):


### PR DESCRIPTION
This can help frontend to determine whether the user is activated or not.
Also a minor fix to empty `user.url` field in the serializer.
.
## Check list

- [x] My branch is up to date with `master`. [How?](https://github.com/ExiaSR/hyperion/wiki/How-to-collaborate)
- [ ] I passed all integration tests in Travis CI.
- [ ] Now it is a good time to ask for review.
