### PR TITLE
fix: user display name is broken after login

### DIFF
--- a/client/src/stores/auth-store.js
+++ b/client/src/stores/auth-store.js
@@ -54,10 +54,8 @@ class AuthStore extends Container {
         'basic_auth',
         window.btoa(`${username}:${password}`)
       );
-      window.localStorage.setItem(
-        'user_info',
-        JSON.stringify(camelcaseKeys(user))
-      );
+      user = camelcaseKeys(user);
+      window.localStorage.setItem('user_info', JSON.stringify(user));
       this.setState({ user });
     } catch (err) {
       console.error(err.response);


### PR DESCRIPTION
TODO: Maybe by default we can transform all json keys to camelcase.

## Related User Stories

_[tag](https://help.github.com/en/articles/autolinked-references-and-urls) related stories or create a new one if does not exist_

## Check list

- [ ] My branch is up to date with `master`. [How?](https://github.com/ExiaSR/hyperion/wiki/How-to-collaborate)
- [ ] I passed all integration tests in Travis CI.
- [ ] Now it is a good time to ask for review.
