### PR TITLE
fix: private post sharing works now

### DIFF
--- a/hyperion/models/post.py
+++ b/hyperion/models/post.py
@@ -43,10 +43,6 @@ class Post(models.Model):
     description = models.TextField(null=True, blank=True)
     unlisted = models.BooleanField(default=False)
 
-    def save(self, force_insert=False, force_update=False, using=None, update_fields=None):
-        super().save()
-        self.visible_to.set([self.author])
-
     def __str__(self):
         return super().__str__() + " post: " + str(self.author.pk)
 


### PR DESCRIPTION
Fixed regression bug introduces in #109 

https://github.com/ExiaSR/hyperion/pull/109/files#diff-b33d91e922f4d6b0c48cc8ebfe1eee9aR50

This overrides the `visible_to` field when creating a new post.

https://github.com/ExiaSR/hyperion/pull/109/files#diff-b33d91e922f4d6b0c48cc8ebfe1eee9aR74

Also, `is_accessible` should not use `visible_to` to check if the author can comment on their own post or not

## Check list

- [ ] My branch is up to date with `master`. [How?](https://github.com/ExiaSR/hyperion/wiki/How-to-collaborate)
- [ ] I passed all integration tests in Travis CI.
- [ ] Now it is a good time to ask for review.
- [ ] Block by #112 