### PR TITLE
fix: broken local author profile page url

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -25,9 +25,17 @@
     <title>Hyperion - A CMPUT 404 Project</title>
     <script>
       // Our primary server hostname, it is here for the convinence of local development
-      window.OUR_HOSTNAME = [
-        'https://cmput404-front.herokuapp.com'
-      ];
+      let { host, protocol } = window.location;
+      if ('%NODE_ENV%' === 'production') {
+        window.OUR_HOSTNAME = [
+          `${protocol}//${host}`
+        ];
+      } else {
+        window.OUR_HOSTNAME = [
+          'https://cmput404-front.herokuapp.com',
+          `${protocol}//${host}`
+        ];
+      }
     </script>
   </head>
   <body>

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -26,11 +26,19 @@
     <script>
       // Our primary server hostname, it is here for the convinence of local development
       let { host, protocol } = window.location;
-      if ('%NODE_ENV%' === 'production') {
+      if ('%REACT_APP_NETLIFY%' === 'true') {
+        // Netlify preview
         window.OUR_HOSTNAME = [
-          `${protocol}//${host}`
+          `${protocol}//${host}`,
+          'https://cmput404-front.herokuapp.com',
+        ];
+      } else if ('%NODE_ENV%' === 'production') {
+        // Heroku production
+        window.OUR_HOSTNAME = [
+          `${protocol}//${host}`,
         ];
       } else {
+        // Local dev or testing
         window.OUR_HOSTNAME = [
           'https://cmput404-front.herokuapp.com',
           `${protocol}//${host}`

--- a/client/src/components/profile-popover.js
+++ b/client/src/components/profile-popover.js
@@ -59,8 +59,8 @@ function ProfilePopover({ author, stores: [authStore] }) {
               to={
                 // Handling for authors from foreign servers
                 window.OUR_HOSTNAME.includes(author.host)
-                  ? author.id
-                  : author.id
+                  ? `/${author.id.substr(author.id.lastIndexOf('/') + 1)}`
+                  : `/${author.id}`
               }
             >
               {author.displayName}

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   base = "client"
-  command = "yarn build"
+  command = "REACT_APP_NETLIFY=true yarn build"
   publish = "client/build/"
 
 [build.environment]


### PR DESCRIPTION
Added special handling for Netlify preview deployment

Local author profile page URL should have the convention of
`<hostname>/<pk>`

Foreign author profile page URL
`<hostname>/encodeURIComponent(<full_url>)`

## Related User Stories

_[tag](https://help.github.com/en/articles/autolinked-references-and-urls) related stories or create a new one if does not exist_

## Check list

- [x] My branch is up to date with `master`. [How?](https://github.com/ExiaSR/hyperion/wiki/How-to-collaborate)
- [ ] I passed all integration tests in Travis CI.
- [ ] Now it is a good time to ask for review.
