### PR TITLE
fix: PostStream won't refetch posts when rerender

### DIFF
--- a/client/src/stores/post-store.js
+++ b/client/src/stores/post-store.js
@@ -21,7 +21,7 @@ class PostsStore extends Container {
    * @param {bool} cached - Whether or not to re-fetch posts from remote
    */
   getAll = async (cached = true) => {
-    if (cached && this.state.posts.length > 0) return;
+    if (cached && this.state.posts.size > 0) return;
     let { posts: postsList, count } = await API.Post.fetchAll();
     if (count > 0) {
       let { posts } = this.state;


### PR DESCRIPTION
In the previous implementation,
PostStore fails to properly check whether there are posts
cached locally or not.

## Check list

- [x] My branch is up to date with `master`. [How?](https://github.com/ExiaSR/hyperion/wiki/How-to-collaborate)
- [x] I passed all integration tests in Travis CI.
- [x] Now it is a good time to ask for review.
