### PR TITLE
fix: fail to get individual post

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -16,6 +16,7 @@
     "lodash.pick": "^4.4.0",
     "lodash.pickby": "^4.6.0",
     "markdown-draft-js": "^1.4.0",
+    "normalize-url": "^4.2.0",
     "prop-types": "^15.7.2",
     "query-string": "^6.2.0",
     "react": "^16.8.5",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -8454,6 +8454,11 @@ normalize-url@^3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
   integrity sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
 
+normalize-url@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.2.0.tgz#e747f16b58e6d7f391495fd86415fa04ec7c9897"
+  integrity sha512-n69+KXI+kZApR+sPwSkoAXpGlNkaiYyoHHqKOFPjJWvwZpew/EjKvuPE4+tStNgb42z5yLtdakgZCQI+LalSPg==
+
 npm-bundled@^1.0.1:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.5.tgz#3c1732b7ba936b3a10325aef616467c0ccbcc979"

--- a/hyperion/tests/tests_post_api.py
+++ b/hyperion/tests/tests_post_api.py
@@ -10,127 +10,108 @@ from django.conf import settings
 
 
 class PostViewTestCase(TestCase):
-    username = '2haotianzhu'
-    password = '123456'
+    username = "2haotianzhu"
+    password = "123456"
 
     def setUp(self):
         # friend of hyuntian
         self.u_1 = User.objects.create_user(
-            username='2haotianzhu',
-            first_name='haotian',
-            last_name='zhu',
-            password='123456')
+            username="2haotianzhu", first_name="haotian", last_name="zhu", password="123456"
+        )
         # friend of 2haotianzhu
         self.u_2 = User.objects.create_user(
-            username='hyuntian',
-            first_name='yuntian',
-            last_name='zhang',
-            password='123456')
+            username="hyuntian", first_name="yuntian", last_name="zhang", password="123456"
+        )
         Friend.objects.create(profile1=self.u_1.profile, profile2=self.u_2.profile)
         # foaf 2haotianzhu friend of hyuntian
         self.u_3 = User.objects.create_user(
-            username='yuntian1',
-            first_name='yuntian',
-            last_name='zhang',
-            password='123456')
+            username="yuntian1", first_name="yuntian", last_name="zhang", password="123456"
+        )
         Friend.objects.create(profile1=self.u_2.profile, profile2=self.u_3.profile)
         # foaf 2haotianzhu friend of hyuntian
         self.u_4 = User.objects.create_user(
-            username='yuntian2',
-            first_name='yuntian',
-            last_name='zhang',
-            password='123456')
+            username="yuntian2", first_name="yuntian", last_name="zhang", password="123456"
+        )
         Friend.objects.create(profile1=self.u_2.profile, profile2=self.u_4.profile)
         # public stranger
         self.u_5 = User.objects.create_user(
-            username='stranger',
-            first_name='yuntian',
-            last_name='zhang',
-            password='123456')
+            username="stranger", first_name="yuntian", last_name="zhang", password="123456"
+        )
         # private stranger
         self.u_6 = User.objects.create_user(
-            username='_stranger',
-            first_name='yuntian',
-            last_name='zhang',
-            password='123456')
+            username="_stranger", first_name="yuntian", last_name="zhang", password="123456"
+        )
 
-        credentials = base64.b64encode('{}:{}'.format(
-            self.username, self.password).encode()).decode()
-        self.client = Client(HTTP_AUTHORIZATION='Basic {}'.format(credentials))
+        credentials = base64.b64encode(
+            "{}:{}".format(self.username, self.password).encode()
+        ).decode()
+        self.client = Client(HTTP_AUTHORIZATION="Basic {}".format(credentials))
 
     def test_get_one(self):
-        Post.objects.create(
-            author=self.u_1.profile, title="1", content="test1")
-        response = self.client.get('/posts')
+        Post.objects.create(author=self.u_1.profile, title="1", content="test1")
+        response = self.client.get("/posts")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data['posts']), 1)
-        self.assertEqual(response.data['posts'][0]['author']['display_name'],
-                         '2haotianzhu')
+        self.assertEqual(len(response.data["posts"]), 1)
+        self.assertEqual(response.data["posts"][0]["author"]["display_name"], "2haotianzhu")
 
     def test_get_many(self):
-        Post.objects.create(
-            author=self.u_1.profile, title="2", content="test2")
-        Post.objects.create(
-            author=self.u_1.profile, title="3", content="test3")
-        response = self.client.get('/posts')
+        Post.objects.create(author=self.u_1.profile, title="2", content="test2")
+        Post.objects.create(author=self.u_1.profile, title="3", content="test3")
+        response = self.client.get("/posts")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data['posts']), 2)
+        self.assertEqual(len(response.data["posts"]), 2)
 
     def test_get_post_by_id(self):
-        Post.objects.create(
-            author=self.u_1.profile, title="4", content="test4")
+        Post.objects.create(author=self.u_1.profile, title="4", content="test4")
         the_id = Post.objects.get().pk
-        path = '/posts/{}'.format(the_id)
+        path = "/posts/{}".format(the_id)
         response = self.client.get(path)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data['post']['author']['display_name'],
-                         '2haotianzhu')
+        self.assertEqual(response.data["posts"][0]["author"]["display_name"], "2haotianzhu")
 
     def test_get_auth_posts(self):
         # get post by auth
 
         # own
-        p_5 = Post.objects.create(author=self.u_1.profile, title="5", content="test", visibility="PRIVATE")
-        p_5 .visible_to.set([self.u_1.profile])
+        p_5 = Post.objects.create(
+            author=self.u_1.profile, title="5", content="test", visibility="PRIVATE"
+        )
+        p_5.visible_to.set([self.u_1.profile])
 
         # public
-        Post.objects.create(
-            author=self.u_5.profile, title="6", content="test", visibility="PUBLIC")
+        Post.objects.create(author=self.u_5.profile, title="6", content="test", visibility="PUBLIC")
         # friends
         Post.objects.create(
-            author=self.u_2.profile, title="7", content="test", visibility="FRIENDS")
+            author=self.u_2.profile, title="7", content="test", visibility="FRIENDS"
+        )
         # foaf
-        Post.objects.create(
-            author=self.u_4.profile, title="8", content="test", visibility="FOAF")
+        Post.objects.create(author=self.u_4.profile, title="8", content="test", visibility="FOAF")
 
         # private can see
-        p_10 = Post.objects.create(author=self.u_6.profile, title="10", content="test", visibility="PRIVATE")
+        p_10 = Post.objects.create(
+            author=self.u_6.profile, title="10", content="test", visibility="PRIVATE"
+        )
         p_10.visible_to.set([self.u_1.profile])
 
         # private cant see
         Post.objects.create(
-            author=self.u_5.profile, title="9", content="test", visibility="PRIVATE")
-        response = self.client.get('/author/posts')
+            author=self.u_5.profile, title="9", content="test", visibility="PRIVATE"
+        )
+        response = self.client.get("/author/posts")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data['query'], 'posts')
-        self.assertEqual(len(response.data['posts']), 5)
+        self.assertEqual(response.data["query"], "posts")
+        self.assertEqual(len(response.data["posts"]), 5)
 
     def test_auth_post_a_post(self):
         data = {
             "query": "createPost",
-            "post": {
-                "title": "test",
-                "content_type": "text/plain",
-                "content": "some post content",
-            }
+            "post": {"title": "test", "content_type": "text/plain", "content": "some post content"},
         }
-        response = self.client.post(
-            '/author/posts', data, content_type='application/json')
+        response = self.client.post("/author/posts", data, content_type="application/json")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data['query'], 'createPost')
-        self.assertEqual(response.data['success'], True)
-        self.assertEqual(Post.objects.all()[0].author.display_name,
-                         '2haotianzhu')
+        self.assertEqual(response.data["query"], "createPost")
+        self.assertEqual(response.data["success"], True)
+        self.assertEqual(Post.objects.all()[0].author.display_name, "2haotianzhu")
 
     def test_unlisted_cases(self):
         data1 = {
@@ -140,7 +121,7 @@ class PostViewTestCase(TestCase):
                 "content_type": "text/plain",
                 "content": "some post content",
                 "unlisted": True,
-            }
+            },
         }
         data2 = {
             "query": "createPost",
@@ -149,24 +130,22 @@ class PostViewTestCase(TestCase):
                 "content_type": "text/plain",
                 "content": "some post content",
                 "unlisted": False,
-            }
+            },
         }
-        response = self.client.post(
-            '/author/posts', data1, content_type='application/json')
+        response = self.client.post("/author/posts", data1, content_type="application/json")
         self.assertEqual(response.status_code, 200)
-        response = self.client.post(
-            '/author/posts', data2, content_type='application/json')
+        response = self.client.post("/author/posts", data2, content_type="application/json")
         self.assertEqual(response.status_code, 200)
-        response = self.client.get('/posts')
+        response = self.client.get("/posts")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data['posts']), 1)
-        self.assertEqual(response.data['posts'][0]['title'], 'unlisted False')
-        post = Post.objects.get(title='unlisted False')
-        response = self.client.get('/posts/{}'.format(post.id))
+        self.assertEqual(len(response.data["posts"]), 1)
+        self.assertEqual(response.data["posts"][0]["title"], "unlisted False")
+        post = Post.objects.get(title="unlisted False")
+        response = self.client.get("/posts/{}".format(post.id))
         self.assertEqual(response.status_code, 200)
-        post = Post.objects.get(title='unlisted True')
-        response = self.client.get('/posts/{}'.format(post.id))
+        post = Post.objects.get(title="unlisted True")
+        response = self.client.get("/posts/{}".format(post.id))
         self.assertEqual(response.status_code, 200)
-        response = self.client.delete('/posts/{}'.format(post.id))
+        response = self.client.delete("/posts/{}".format(post.id))
         self.assertEqual(response.status_code, 204)
         self.assertEqual(len(Post.objects.all()), 1)

--- a/hyperion/utils.py
+++ b/hyperion/utils.py
@@ -1,7 +1,12 @@
+# pylint: disable=logging-not-lazy,invalid-name
+
+import logging
 import requests
 import humps
 
 from hyperion.models import Server
+
+logger = logging.getLogger(__name__)
 
 
 class ForeignServerHttpUtils:
@@ -10,7 +15,7 @@ class ForeignServerHttpUtils:
         foreign_url = "{}{}{}".format(
             server.endpoint, url, "/" if server.required_trailing_slash else ""
         )
-        print("[%s] HTTP/1.1 GET %s" % (__name__, foreign_url))
+        logger.info("[%s] HTTP/1.1 GET %s" % (__name__, foreign_url))
         return requests.get(
             foreign_url, auth=(server.foreign_db_username, server.foreign_db_password), **kwargs
         )
@@ -20,7 +25,7 @@ class ForeignServerHttpUtils:
         foreign_url = "{}{}{}".format(
             server.endpoint, url, "/" if server.required_trailing_slash else ""
         )
-        print("[%s] HTTP/1.1 POST %s" % (__name__, foreign_url))
+        logger.info("[%s] HTTP/1.1 POST %s" % (__name__, foreign_url))
         camalized_json = humps.camelize([json])[0]
         return requests.post(
             foreign_url,


### PR DESCRIPTION
Frontend failed to normalize the post id/url, result on double forward slash when
doing string contactation

Backend API `/post/:id` is not following spec when returnning local post

# Related User Stories

_[tag](https://help.github.com/en/articles/autolinked-references-and-urls) related stories or create a new one if does not exist_

## Check list

- [x] My branch is up to date with `master`. [How?](https://github.com/ExiaSR/hyperion/wiki/How-to-collaborate)
- [x] I passed all integration tests in Travis CI.
- [x] Now it is a good time to ask for review.
